### PR TITLE
Fixed nginx root directory

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -3,7 +3,7 @@ server {
 	index index.php index.html;
 	error_log /var/log/nginx/error.log;
 	access_log /var/log/nginx/access.log;
-	root /var/www/app/public;
+	root /var/www/app;
 
 	add_header 'Access-Control-Allow-Origin' '*' always;
     add_header 'Access-Control-Allow-Methods' '*' always;


### PR DESCRIPTION
Corrected root directive in server block.

Previously, the root directive was set to /var/www/app/public, which caused issues as the Laravel application's public directory is located at /var/www/app. This change aligns the root directive with the correct directory structure.